### PR TITLE
Add support for sprunge.us

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,6 +25,9 @@ features(
         'File::Temp',
         'File::Spec'
     ],
+    'sprunge.us support' => [
+        'WWW::Pastebin::Sprunge::Create',
+    ],
 );
 
 install_script 'bin/nopaste';

--- a/lib/App/Nopaste.pm
+++ b/lib/App/Nopaste.pm
@@ -156,7 +156,8 @@ message and the service that issued it.
 
 =head1 SEE ALSO
 
-L<WebService::NoPaste>, L<WWW::PastebinCom::Create>, L<WWW::Rafb::Create>, L<Devel::REPL::Plugin::Nopaste>
+L<WebService::NoPaste>, L<WWW::PastebinCom::Create>, L<WWW::Rafb::Create>,
+L<Devel::REPL::Plugin::Nopaste>, L<WWW::Pastebin::Sprunge::Create>.
 
 =head1 AUTHOR
 
@@ -170,4 +171,3 @@ This program is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.
 
 =cut
-

--- a/t/000-load.t
+++ b/t/000-load.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 7;
+use Test::More tests => 8;
 
 use_ok 'App::Nopaste';
 use_ok 'App::Nopaste::Service';
@@ -9,4 +9,4 @@ use_ok 'App::Nopaste::Service::Husk';
 use_ok 'App::Nopaste::Service::Snitch';
 use_ok 'App::Nopaste::Service::PastebinCom';
 use_ok 'App::Nopaste::Service::Mathbin';
-
+use_ok 'App::Nopaste::Service::Sprunge';


### PR DESCRIPTION
Hi,

This adds support for the http://sprunge.us pastebin. It relies on [`App::Nopaste::Service::Sprunge`](http://github.com/doherty/App-Nopaste-Service-Sprunge) and [`WWW::Pastebin::Sprunge::Create`](http://github.com/doherty/WWW-Pastebin-Sprunge-Create), which you may also wish to review (as a beginning coder, I'm open to criticism and advice).

Thanks,
-Mike
