### PR TITLE
Correct Pastie service URL

### DIFF
--- a/lib/App/Nopaste/Service/Pastie.pm
+++ b/lib/App/Nopaste/Service/Pastie.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use base 'App::Nopaste::Service';
 
-sub uri { 'http://pastie.caboo.se/pastes/create' }
+sub uri { 'http://pastie.org/' }
 
 sub fill_form {
     my $self = shift;


### PR DESCRIPTION
Corrects the URL in the Pastie service, which is currently defunct.

Apologies for sending this pull request again; just figured it'd be better to split up the two requests, to let you decide separately.
