### PR TITLE
tell the user if LWP is preventing the gist from gisting

### DIFF
--- a/lib/App/Nopaste/Service/Gist.pm
+++ b/lib/App/Nopaste/Service/Gist.pm
@@ -71,6 +71,10 @@ sub _get_auth {
 sub return {
     my ($self, $res) = @_;
 
+    if (($res->header('Client-Warning') || '') eq 'Internal response') {
+      return (0, "LWP Error: " . $res->content);
+    }
+
     my ($id) = $res->content =~ qr{"repo":"([0-9a-f]+)"};
 
     return (0, "Could not find paste link.") if !$id;


### PR DESCRIPTION
as discussed on IRC; if LWP has produced a client-side error "response," report the error
