### PR TITLE
SSH: optionally use the supplied description in the paste filename

### DIFF
--- a/lib/App/Nopaste/Service/ssh.pm
+++ b/lib/App/Nopaste/Service/ssh.pm
@@ -24,7 +24,10 @@ sub run {
 
     my $suffix = $ext;
     if ($usedesc) {
-        $args{'desc'} ||= $source || '';
+        if (not $args{'desc'}) {
+            my ($vol, $dirs, $file) = File::Spec->splitpath($source);
+            $args{'desc'} = $file || '';
+        }
         $suffix = ($args{'desc'} ? '-' : '') . $args{'desc'} . $suffix;
     }
 


### PR DESCRIPTION
It defaults to the source filename, if any, but may be overridden by the
-d option.
