### PR TITLE
Fix App::Nopaste::ssh's new filename description feature

### DIFF
--- a/lib/App/Nopaste/Command.pm
+++ b/lib/App/Nopaste/Command.pm
@@ -92,6 +92,12 @@ has private => (
     documentation => "If specified, paste privately to services where possible.",
 );
 
+has filename => (
+    is            => 'rw',
+    isa           => 'Str',
+    builder       => 'detect_filename'
+);
+
 sub run {
     my $self = shift;
 

--- a/lib/App/Nopaste/Command.pm
+++ b/lib/App/Nopaste/Command.pm
@@ -94,7 +94,7 @@ has private => (
 
 has filename => (
     is            => 'rw',
-    isa           => 'Str',
+    isa           => 'Maybe[Str]',
     builder       => 'detect_filename'
 );
 


### PR DESCRIPTION
With 9453220, Command.pm stopped building %args explicitly

A few commits before, filename started being built from detect_filename,
but now it doesn't get passed.  This causes get_all_attributes to find
and build filename for App::Nopaste::Command::ssh
