### PR TITLE
basic auth for gist API support

### DIFF
--- a/lib/App/Nopaste/Service/Gist.pm
+++ b/lib/App/Nopaste/Service/Gist.pm
@@ -25,7 +25,7 @@ sub run {
 
     my $filename = defined $arg{filename}
                  ? File::Basename::basename($arg{filename})
-                 : 'nopaste.txt';
+                 : 'nopaste';
 
     $content->{files} = {
         $filename => {


### PR DESCRIPTION
Allow setting GITHUB_USER and GITHUB_PASSWORD env vars, if
GITHUB_OAUTH_TOKEN is not set to use basic auth with the API.
