### PR TITLE
Filename extensions do not contain slashes

### DIFF
--- a/lib/App/Nopaste/Service/ssh.pm
+++ b/lib/App/Nopaste/Service/ssh.pm
@@ -21,7 +21,7 @@ sub run {
                     : 1;
 
     my $date = strftime("%Y-%m-%d",localtime());
-    my ($ext) = defined $source && $source =~ s/(\.[^.]+?)$// ? $1 : '';
+    my ($ext) = defined $source && $source =~ s/(\.[^.\/\\]+?)$// ? $1 : '';
 
     my $suffix = $ext;
     if ($usedesc) {


### PR DESCRIPTION
Now filenames like "../foo" don't extract a bogus extension of "./foo".
